### PR TITLE
Improved eslint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,53 @@
 {
-  "extends": "airbnb",
+  "parser": "babel-eslint",
+  "extends": "standard",
+  "plugins": [
+    "babel"
+  ],
   "rules": {
-    "comma-dangle": ["error", "never"]
+    "comma-dangle": [
+      "error",
+      "never"
+    ],
+    "max-len": [
+      "error",
+      {
+        "code": 120,
+        "tabWidth": 2,
+        "ignoreStrings": true,
+        "ignoreTemplateLiterals": true,
+        "ignoreRegExpLiterals": true,
+        "ignorePattern": "^\\s*var\\s.+=\\s*require\\s*\\(/"
+      }
+    ],
+    "no-param-reassign": [
+      "error", {
+        "props": false
+      }
+    ],
+    "no-trailing-spaces": [
+      "error", {
+        "skipBlankLines": true
+      }
+    ],
+    "no-unused-expressions": [
+      "error", {
+        "allowTernary": true
+      }
+    ],
+    "no-use-before-define": [
+      "error", {
+        "functions": false,
+        "classes": false
+      }
+    ],
+    "object-curly-spacing": [
+      "error",
+      "never"
+    ],
+    "space-before-function-paren": [
+      "error",
+      "never"
+    ]
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -45,6 +45,10 @@
       "error",
       "never"
     ],
+    "semi": [
+      "error",
+      "always"
+    ],
     "space-before-function-paren": [
       "error",
       "never"


### PR DESCRIPTION
## What this PR does?

- Change the base extension of the eslint rules
- Redefine some of the rules

### Before 

- Airbnb base extension
- Missing rules

### After

- Standard base extension
- New rules

### Dependencies
```JSON
...
    "babel-eslint": "^7.2.1",
    "eslint": "^3.19.0",
    "eslint-config-standard": "^10.1.0",
    "eslint-plugin-babel": "^4.1.1",
    "eslint-plugin-import": "^2.2.0",
    "eslint-plugin-node": "^4.2.2",
    "eslint-plugin-promise": "^3.5.0",
    "eslint-plugin-standard": "^3.0.0"
...
```

### TODOs
- [x] Do we need `;` ? Yes, we need them!

Thanks!
